### PR TITLE
feat(fase-1): novos status, campos de outreach e filtro por nicho

### DIFF
--- a/src/components/leads/LeadDetailSheet.tsx
+++ b/src/components/leads/LeadDetailSheet.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from "react";
-import { Github, RefreshCw, Plus, DollarSign, Briefcase, Mail, Phone, Archive, ArchiveRestore, X, Tag } from "lucide-react";
+import { Github, RefreshCw, Plus, DollarSign, Briefcase, Mail, Phone, Archive, ArchiveRestore, X, Tag, MapPin, Link } from "lucide-react";
 import {
     Sheet,
     SheetContent,
@@ -27,6 +27,7 @@ import { DealForm } from "./DealForm";
 import { DealItem } from "./DealItem";
 import { IssueItem } from "./IssueItem";
 import { EMPTY_DEAL_FORM } from "./LeadForm";
+import { LEAD_STATUSES } from "@/lib/leadStatus";
 
 const PRESET_TAGS = ["Web", "Roblox", "MU Online", "Landing Page", "Mobile", "API", "Automação", "Design"];
 
@@ -47,7 +48,7 @@ export function LeadDetailSheet({
     onClose,
     isSaving,
 }: LeadDetailSheetProps) {
-    const set = (key: keyof Lead, val: string | boolean | null | string[]) =>
+    const set = (key: keyof Lead, val: string | boolean | null | string[] | number) =>
         onEditFormChange({ ...editForm, [key]: val });
 
     const archiveLead = useArchiveLead();
@@ -118,10 +119,14 @@ export function LeadDetailSheet({
                             </SheetTitle>
                             <SheetDescription>{lead.company}</SheetDescription>
                         </div>
-                        {totalDealsValue > 0 && (
+                        {/* Mostra price_usd em USD se disponível, senão total de deals em R$ */}
+                        {(lead.price_usd != null || totalDealsValue > 0) && (
                             <div className="flex items-center gap-1.5 bg-primary/10 text-primary px-2.5 py-1 rounded-md text-xs font-semibold shrink-0">
                                 <DollarSign className="w-3.5 h-3.5" />
-                                R$ {totalDealsValue.toLocaleString("pt-BR", { minimumFractionDigits: 2 })}
+                                {lead.price_usd != null
+                                    ? `$${lead.price_usd.toLocaleString("en-US", { minimumFractionDigits: 0 })}`
+                                    : `R$ ${totalDealsValue.toLocaleString("pt-BR", { minimumFractionDigits: 2 })}`
+                                }
                             </div>
                         )}
                     </div>
@@ -198,6 +203,73 @@ export function LeadDetailSheet({
                         </div>
                     </div>
 
+                    {/* Issue #2 — Cidade, Nicho, Demo URL, Valor USD */}
+                    <div className="grid grid-cols-2 gap-3">
+                        <div className="space-y-1.5">
+                            <Label className="text-xs text-muted-foreground flex items-center gap-1">
+                                <MapPin className="w-3 h-3" /> Cidade
+                            </Label>
+                            <Input
+                                value={editForm.city ?? ""}
+                                onChange={(e) => set("city", e.target.value || null)}
+                                className="bg-background border-border/60 text-sm"
+                                placeholder="Austin, TX"
+                            />
+                        </div>
+                        <div className="space-y-1.5">
+                            <Label className="text-xs text-muted-foreground flex items-center gap-1">
+                                <Tag className="w-3 h-3" /> Nicho
+                            </Label>
+                            <Input
+                                value={editForm.niche ?? ""}
+                                onChange={(e) => set("niche", e.target.value || null)}
+                                className="bg-background border-border/60 text-sm"
+                                placeholder="Dentista, Academia..."
+                            />
+                        </div>
+                    </div>
+
+                    <div className="grid grid-cols-2 gap-3">
+                        <div className="space-y-1.5">
+                            <Label className="text-xs text-muted-foreground flex items-center gap-1">
+                                <Link className="w-3 h-3" /> Demo URL
+                            </Label>
+                            <div className="flex gap-1">
+                                <Input
+                                    value={editForm.demo_url ?? ""}
+                                    onChange={(e) => set("demo_url", e.target.value || null)}
+                                    className="bg-background border-border/60 text-sm"
+                                    placeholder="https://demo.lovable.app/..."
+                                />
+                                {editForm.demo_url && (
+                                    <a
+                                        href={editForm.demo_url.startsWith("http") ? editForm.demo_url : `https://${editForm.demo_url}`}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="flex items-center px-2 rounded-md border border-border/60 bg-background text-muted-foreground hover:text-primary transition-colors"
+                                    >
+                                        <Link className="w-3.5 h-3.5" />
+                                    </a>
+                                )}
+                            </div>
+                        </div>
+                        <div className="space-y-1.5">
+                            <Label className="text-xs text-muted-foreground flex items-center gap-1">
+                                <DollarSign className="w-3 h-3" /> Valor (USD)
+                            </Label>
+                            <Input
+                                type="number"
+                                min={0}
+                                value={editForm.price_usd ?? ""}
+                                onChange={(e) =>
+                                    set("price_usd", e.target.value ? parseFloat(e.target.value) : null)
+                                }
+                                className="bg-background border-border/60 text-sm"
+                                placeholder="1200"
+                            />
+                        </div>
+                    </div>
+
                     <div className="space-y-1.5">
                         <Label className="text-xs text-muted-foreground">Repo URL</Label>
                         <div className="flex gap-2">
@@ -213,6 +285,7 @@ export function LeadDetailSheet({
                         </div>
                     </div>
 
+                    {/* Issue #1 — select de status com novos valores */}
                     <div className="grid grid-cols-2 gap-3">
                         <div className="space-y-1.5">
                             <Label className="text-xs text-muted-foreground">Status</Label>
@@ -221,9 +294,9 @@ export function LeadDetailSheet({
                                     <SelectValue />
                                 </SelectTrigger>
                                 <SelectContent>
-                                    <SelectItem value="new">Novo</SelectItem>
-                                    <SelectItem value="in-progress">Em Progresso</SelectItem>
-                                    <SelectItem value="done">Concluído</SelectItem>
+                                    {LEAD_STATUSES.map((s) => (
+                                        <SelectItem key={s.value} value={s.value}>{s.label}</SelectItem>
+                                    ))}
                                 </SelectContent>
                             </Select>
                         </div>
@@ -243,7 +316,6 @@ export function LeadDetailSheet({
                         <Label className="text-xs text-muted-foreground flex items-center gap-1">
                             <Tag className="w-3 h-3" /> Tags
                         </Label>
-                        {/* Tags atuais */}
                         {currentTags.length > 0 && (
                             <div className="flex flex-wrap gap-1.5">
                                 {currentTags.map((tag) => (
@@ -259,7 +331,6 @@ export function LeadDetailSheet({
                                 ))}
                             </div>
                         )}
-                        {/* Sugestões */}
                         <div className="flex flex-wrap gap-1">
                             {PRESET_TAGS.filter((t) => !currentTags.includes(t)).map((tag) => (
                                 <button
@@ -271,7 +342,6 @@ export function LeadDetailSheet({
                                 </button>
                             ))}
                         </div>
-                        {/* Input personalizado */}
                         <div className="flex gap-2">
                             <Input
                                 value={tagInput}

--- a/src/components/leads/LeadForm.tsx
+++ b/src/components/leads/LeadForm.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, DollarSign, Github } from "lucide-react";
+import { ChevronDown, DollarSign, Github, Link, MapPin, Tag } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -10,6 +10,7 @@ import {
     SelectValue,
 } from "@/components/ui/select";
 import { LeadInsert } from "@/hooks/useLeads";
+import { LEAD_STATUSES } from "@/lib/leadStatus";
 
 export const EMPTY_DEAL_FORM = {
     title: "",
@@ -35,7 +36,7 @@ export function LeadForm({
     showDealSection,
     onToggleDealSection,
 }: LeadFormProps) {
-    const set = (key: keyof LeadInsert, val: string | boolean | null) =>
+    const set = (key: keyof LeadInsert, val: string | boolean | number | null) =>
         onChange({ ...form, [key]: val });
 
     return (
@@ -61,6 +62,32 @@ export function LeadForm({
                 </div>
             </div>
 
+            {/* Issue #2 — Cidade e Nicho */}
+            <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1.5">
+                    <Label className="text-xs text-muted-foreground flex items-center gap-1">
+                        <MapPin className="w-3 h-3" /> Cidade
+                    </Label>
+                    <Input
+                        value={form.city ?? ""}
+                        onChange={(e) => set("city", e.target.value || null)}
+                        className="bg-background border-border/60 text-sm"
+                        placeholder="Austin, TX"
+                    />
+                </div>
+                <div className="space-y-1.5">
+                    <Label className="text-xs text-muted-foreground flex items-center gap-1">
+                        <Tag className="w-3 h-3" /> Nicho
+                    </Label>
+                    <Input
+                        value={form.niche ?? ""}
+                        onChange={(e) => set("niche", e.target.value || null)}
+                        className="bg-background border-border/60 text-sm"
+                        placeholder="Dentista, Academia..."
+                    />
+                </div>
+            </div>
+
             <div className="grid grid-cols-2 gap-3">
                 <div className="space-y-1.5">
                     <Label className="text-xs text-muted-foreground">Status</Label>
@@ -69,9 +96,9 @@ export function LeadForm({
                             <SelectValue />
                         </SelectTrigger>
                         <SelectContent>
-                            <SelectItem value="new">Novo</SelectItem>
-                            <SelectItem value="in-progress">Em Progresso</SelectItem>
-                            <SelectItem value="done">Concluído</SelectItem>
+                            {LEAD_STATUSES.map((s) => (
+                                <SelectItem key={s.value} value={s.value}>{s.label}</SelectItem>
+                            ))}
                         </SelectContent>
                     </Select>
                 </div>
@@ -82,6 +109,36 @@ export function LeadForm({
                         value={form.deadline ?? ""}
                         onChange={(e) => set("deadline", e.target.value || null)}
                         className="bg-background border-border/60 text-sm"
+                    />
+                </div>
+            </div>
+
+            {/* Issue #2 — Demo URL e Valor USD */}
+            <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1.5">
+                    <Label className="text-xs text-muted-foreground flex items-center gap-1">
+                        <Link className="w-3 h-3" /> Demo URL
+                    </Label>
+                    <Input
+                        value={form.demo_url ?? ""}
+                        onChange={(e) => set("demo_url", e.target.value || null)}
+                        className="bg-background border-border/60 text-sm"
+                        placeholder="https://demo.lovable.app/..."
+                    />
+                </div>
+                <div className="space-y-1.5">
+                    <Label className="text-xs text-muted-foreground flex items-center gap-1">
+                        <DollarSign className="w-3 h-3" /> Valor (USD)
+                    </Label>
+                    <Input
+                        type="number"
+                        min={0}
+                        value={form.price_usd ?? ""}
+                        onChange={(e) =>
+                            set("price_usd", e.target.value ? parseFloat(e.target.value) : null)
+                        }
+                        className="bg-background border-border/60 text-sm"
+                        placeholder="1200"
                     />
                 </div>
             </div>

--- a/src/components/leads/LeadTableRow.tsx
+++ b/src/components/leads/LeadTableRow.tsx
@@ -9,9 +9,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import StatusBadge from "@/components/StatusBadge";
 import { Lead } from "@/hooks/useLeads";
 import { useDeals } from "@/hooks/useDeals";
+import { LEAD_STATUSES, getStatusLabel, getStatusColor } from "@/lib/leadStatus";
 
 interface LeadTableRowProps {
   lead: Lead;
@@ -27,13 +27,15 @@ export function LeadTableRow({ lead, onClick, onStatusChange, onDelete }: LeadTa
   const isOverdue =
     lead.deadline &&
     isBefore(parseISO(lead.deadline), new Date()) &&
-    lead.status !== "done";
+    lead.status !== "done" &&
+    lead.status !== "fechado";
 
   const isDueSoon =
     lead.deadline &&
     !isOverdue &&
     isBefore(parseISO(lead.deadline), addDays(new Date(), 3)) &&
-    lead.status !== "done";
+    lead.status !== "done" &&
+    lead.status !== "fechado";
 
   return (
     <tr
@@ -43,9 +45,17 @@ export function LeadTableRow({ lead, onClick, onStatusChange, onDelete }: LeadTa
       onClick={onClick}
     >
       <td className="p-3">
-        <div className="flex items-center gap-2">
-          <span className="text-xs font-medium text-foreground">{lead.name}</span>
-          {lead.archived && <Archive className="w-3 h-3 text-muted-foreground/50" />}
+        <div className="flex flex-col gap-0.5">
+          <div className="flex items-center gap-2">
+            <span className="text-xs font-medium text-foreground">{lead.name}</span>
+            {lead.archived && <Archive className="w-3 h-3 text-muted-foreground/50" />}
+          </div>
+          {/* Issue #2 — cidade e nicho abaixo do nome */}
+          {(lead.city || lead.niche) && (
+            <span className="text-xs text-muted-foreground/60">
+              {[lead.city, lead.niche].filter(Boolean).join(" · ")}
+            </span>
+          )}
         </div>
       </td>
       <td className="p-3">
@@ -67,17 +77,20 @@ export function LeadTableRow({ lead, onClick, onStatusChange, onDelete }: LeadTa
           )}
         </div>
       </td>
+      {/* Issue #1 — status select com novos valores */}
       <td className="p-3" onClick={(e) => e.stopPropagation()}>
         <Select value={lead.status} onValueChange={onStatusChange}>
           <SelectTrigger className="h-7 text-xs bg-transparent border-none p-0 w-fit gap-1 focus:ring-0">
             <SelectValue>
-              <StatusBadge status={lead.status} />
+              <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${getStatusColor(lead.status)}`}>
+                {getStatusLabel(lead.status)}
+              </span>
             </SelectValue>
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="new">Novo</SelectItem>
-            <SelectItem value="in-progress">Em Progresso</SelectItem>
-            <SelectItem value="done">Concluído</SelectItem>
+            {LEAD_STATUSES.map((s) => (
+              <SelectItem key={s.value} value={s.value}>{s.label}</SelectItem>
+            ))}
           </SelectContent>
         </Select>
       </td>
@@ -98,8 +111,13 @@ export function LeadTableRow({ lead, onClick, onStatusChange, onDelete }: LeadTa
           <span className="text-xs text-muted-foreground/40">—</span>
         )}
       </td>
+      {/* Issue #2 — exibe price_usd se houver, senão valor de deals em R$ */}
       <td className="p-3">
-        {totalValue > 0 ? (
+        {lead.price_usd != null ? (
+          <span className="text-xs font-medium text-primary">
+            ${lead.price_usd.toLocaleString("en-US", { minimumFractionDigits: 0 })}
+          </span>
+        ) : totalValue > 0 ? (
           <span className="text-xs font-medium text-primary">
             R$ {totalValue.toLocaleString("pt-BR", { minimumFractionDigits: 0 })}
           </span>

--- a/src/hooks/useLeads.ts
+++ b/src/hooks/useLeads.ts
@@ -3,6 +3,22 @@ import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/hooks/useAuth";
 import { toast } from "@/hooks/use-toast";
 
+// Issue #1 — novos status do funil de outreach
+// Os valores antigos (new | in-progress | done) são mantidos como fallback
+// para não quebrar dados já existentes no banco.
+export type LeadStatus =
+  | "prospectado"
+  | "demo-criada"
+  | "email-enviado"
+  | "follow-up-1"
+  | "follow-up-2"
+  | "fechado"
+  | "recusado"
+  // legados — mantidos para compatibilidade com registros antigos
+  | "new"
+  | "in-progress"
+  | "done";
+
 export interface Lead {
   id: number;
   user_id: string;
@@ -11,13 +27,20 @@ export interface Lead {
   email: string | null;
   phone: string | null;
   repo_url: string | null;
-  status: "new" | "in-progress" | "done";
+  status: LeadStatus;
   deadline: string | null;
   notes: string | null;
   github_sync: boolean;
   tags: string[] | null;
   archived: boolean;
   created_at: string;
+  // Issue #2 — campos de outreach
+  demo_url: string | null;
+  city: string | null;
+  niche: string | null;
+  price_usd: number | null;
+  // Issue #6 — preenchido após envio de email
+  email_sent_at: string | null;
 }
 
 export type LeadInsert = Omit<Lead, "id" | "created_at" | "user_id">;

--- a/src/lib/leadStatus.ts
+++ b/src/lib/leadStatus.ts
@@ -1,0 +1,44 @@
+import { LeadStatus } from "@/hooks/useLeads";
+
+// Fonte única de verdade para os status do funil de outreach (Issue #1)
+// Usada em LeadForm, LeadTableRow, LeadDetailSheet e Leads.tsx
+export const LEAD_STATUSES: { value: LeadStatus; label: string }[] = [
+  { value: "prospectado",   label: "Prospectado" },
+  { value: "demo-criada",   label: "Demo Criada" },
+  { value: "email-enviado", label: "Email Enviado" },
+  { value: "follow-up-1",   label: "Follow-up 1" },
+  { value: "follow-up-2",   label: "Follow-up 2" },
+  { value: "fechado",       label: "Fechado" },
+  { value: "recusado",      label: "Recusado" },
+];
+
+// Retorna label legível para qualquer status, incluindo valores legados
+export function getStatusLabel(status: LeadStatus): string {
+  const found = LEAD_STATUSES.find((s) => s.value === status);
+  if (found) return found.label;
+  // Fallback para valores antigos que ainda possam existir no banco
+  const legacy: Record<string, string> = {
+    new: "Novo",
+    "in-progress": "Em Progresso",
+    done: "Concluído",
+  };
+  return legacy[status] ?? status;
+}
+
+// Cores por status para badges
+export function getStatusColor(status: LeadStatus): string {
+  switch (status) {
+    case "prospectado":   return "bg-blue-500/15 text-blue-400";
+    case "demo-criada":   return "bg-violet-500/15 text-violet-400";
+    case "email-enviado": return "bg-yellow-500/15 text-yellow-400";
+    case "follow-up-1":   return "bg-orange-500/15 text-orange-400";
+    case "follow-up-2":   return "bg-red-500/15 text-red-400";
+    case "fechado":       return "bg-green-500/15 text-green-400";
+    case "recusado":      return "bg-muted/40 text-muted-foreground";
+    // legados
+    case "new":           return "bg-blue-500/15 text-blue-400";
+    case "in-progress":   return "bg-yellow-500/15 text-yellow-400";
+    case "done":          return "bg-green-500/15 text-green-400";
+    default:              return "bg-muted/40 text-muted-foreground";
+  }
+}

--- a/src/pages/Leads.tsx
+++ b/src/pages/Leads.tsx
@@ -30,6 +30,7 @@ import { Plus, Archive } from "lucide-react";
 import { LeadForm, EMPTY_DEAL_FORM } from "@/components/leads/LeadForm";
 import { LeadTableRow } from "@/components/leads/LeadTableRow";
 import { LeadDetailSheet } from "@/components/leads/LeadDetailSheet";
+import { LEAD_STATUSES } from "@/lib/leadStatus";
 
 const EMPTY_LEAD: LeadInsert = {
   name: "",
@@ -37,12 +38,18 @@ const EMPTY_LEAD: LeadInsert = {
   email: null,
   phone: null,
   repo_url: "",
-  status: "new",
+  status: "prospectado",
   deadline: null,
   notes: "",
   github_sync: false,
   tags: null,
   archived: false,
+  // Issue #2 — campos de outreach
+  demo_url: null,
+  city: null,
+  niche: null,
+  price_usd: null,
+  email_sent_at: null,
 };
 
 export default function Leads() {
@@ -61,12 +68,23 @@ export default function Leads() {
   const [search,         setSearch]         = useState("");
   const [statusFilter,   setStatusFilter]   = useState<string>("all");
   const [tagFilter,      setTagFilter]      = useState<string>("all");
+  // Issue #4 — filtro por nicho
+  const [nichoFilter,    setNichoFilter]    = useState<string>("all");
   const [initialDealForm, setInitialDealForm] = useState(EMPTY_DEAL_FORM);
   const [showDealSection, setShowDealSection] = useState(false);
 
   // Todas as tags existentes
   const allTags = useMemo(
     () => Array.from(new Set(leads.flatMap((l) => l.tags ?? []))).sort(),
+    [leads]
+  );
+
+  // Issue #4 — nichos únicos existentes nos leads cadastrados
+  const allNichos = useMemo(
+    () =>
+      Array.from(
+        new Set(leads.map((l) => l.niche).filter((n): n is string => !!n))
+      ).sort(),
     [leads]
   );
 
@@ -78,9 +96,11 @@ export default function Leads() {
           (l.company ?? "").toLowerCase().includes(search.toLowerCase());
         const matchesStatus = statusFilter === "all" || l.status === statusFilter;
         const matchesTag    = tagFilter === "all" || (l.tags ?? []).includes(tagFilter);
-        return matchesSearch && matchesStatus && matchesTag;
+        // Issue #4 — filtro defensivo: ignora se niche for undefined/null
+        const matchesNicho  = nichoFilter === "all" || (l.niche ?? "") === nichoFilter;
+        return matchesSearch && matchesStatus && matchesTag && matchesNicho;
       }),
-    [leads, search, statusFilter, tagFilter]
+    [leads, search, statusFilter, tagFilter, nichoFilter]
   );
 
   const handleCreate = async () => {
@@ -124,15 +144,21 @@ export default function Leads() {
   const openLead = (lead: Lead) => {
     setSelectedLead(lead);
     setEditForm({
-      name:     lead.name,
-      company:  lead.company ?? "",
-      email:    lead.email ?? "",
-      phone:    lead.phone ?? "",
-      repo_url: lead.repo_url ?? "",
-      status:   lead.status,
-      deadline: lead.deadline,
-      notes:    lead.notes ?? "",
-      tags:     lead.tags ?? [],
+      name:          lead.name,
+      company:       lead.company ?? "",
+      email:         lead.email ?? "",
+      phone:         lead.phone ?? "",
+      repo_url:      lead.repo_url ?? "",
+      status:        lead.status,
+      deadline:      lead.deadline,
+      notes:         lead.notes ?? "",
+      tags:          lead.tags ?? [],
+      // Issue #2 — inclui novos campos no editForm
+      demo_url:      lead.demo_url ?? "",
+      city:          lead.city ?? "",
+      niche:         lead.niche ?? "",
+      price_usd:     lead.price_usd ?? null,
+      email_sent_at: lead.email_sent_at ?? null,
     });
   };
 
@@ -171,17 +197,32 @@ export default function Leads() {
           onChange={(e) => setSearch(e.target.value)}
           className="max-w-xs bg-card border-border/60 text-sm"
         />
+        {/* Issue #1 — filtro de status com novos valores */}
         <Select value={statusFilter} onValueChange={setStatusFilter}>
           <SelectTrigger className="w-44 bg-card border-border/60 text-sm">
             <SelectValue placeholder="Status" />
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="all">Todos os status</SelectItem>
-            <SelectItem value="new">Novo</SelectItem>
-            <SelectItem value="in-progress">Em Progresso</SelectItem>
-            <SelectItem value="done">Concluído</SelectItem>
+            {LEAD_STATUSES.map((s) => (
+              <SelectItem key={s.value} value={s.value}>{s.label}</SelectItem>
+            ))}
           </SelectContent>
         </Select>
+        {/* Issue #4 — filtro por nicho (só aparece se houver nichos cadastrados) */}
+        {allNichos.length > 0 && (
+          <Select value={nichoFilter} onValueChange={setNichoFilter}>
+            <SelectTrigger className="w-44 bg-card border-border/60 text-sm">
+              <SelectValue placeholder="Nicho" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Todos os nichos</SelectItem>
+              {allNichos.map((n) => (
+                <SelectItem key={n} value={n}>{n}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
         {allTags.length > 0 && (
           <Select value={tagFilter} onValueChange={setTagFilter}>
             <SelectTrigger className="w-44 bg-card border-border/60 text-sm">


### PR DESCRIPTION
- Issue #1: atualiza Lead['status'] com 7 novos valores do funil de outreach (mantém 'new'|'in-progress'|'done' como fallback no StatusBadge)
- Issue #2: adiciona demo_url, city, niche, price_usd em useLeads, LeadForm, LeadDetailSheet, Leads.tsx (EMPTY_LEAD e openLead)
- Issue #4: filtro por nicho na página Leads com useMemo defensivo